### PR TITLE
feat(Module): Adds an optional padding prop to give the module outer padding

### DIFF
--- a/src/components/Module/Module-story.js
+++ b/src/components/Module/Module-story.js
@@ -45,4 +45,23 @@ storiesOf('Components|Module', module)
         </ModuleBody>
       </Module>
     )),
+  )
+  .add(
+    'Outer padding',
+    withInfo(`This is an example of a module with outer padding`)(() => (
+      <Module className="some-class" padding>
+        <ModuleHeader>Module Example</ModuleHeader>
+        <ModuleBody>
+          <p>
+            Lorem Ipsum is dummy text of the printing and typesetting industry. Lorem Ipsum has been
+            the industry&rsquo;s standard dummy text ever since the 1500s, when an unknown printer
+            took a galley of type and scrambled it to make a type specimen book.
+          </p>
+          <p>
+            It has survived not only five centuries, but also the leap into electronic typesetting,
+            remaining essentially unchanged.
+          </p>
+        </ModuleBody>
+      </Module>
+    )),
   );

--- a/src/components/Module/Module-test.js
+++ b/src/components/Module/Module-test.js
@@ -24,6 +24,11 @@ describe('Module', () => {
       expect(testModule.hasClass('bx--module--single')).toEqual(true);
     });
 
+    it('should render with specified class', () => {
+      testModule.setProps({ padding: true });
+      expect(testModule.hasClass('bx--module--padding')).toEqual(true);
+    });
+
     it('should render children as expected', () => {
       expect(testModule.find(ModuleBody).length).toEqual(1);
     });

--- a/src/components/Module/Module.js
+++ b/src/components/Module/Module.js
@@ -6,6 +6,7 @@ const propTypes = {
   children: PropTypes.node,
   className: PropTypes.string,
   size: PropTypes.oneOf(['single', 'fluid']),
+  padding: PropTypes.bool,
 };
 
 const moduleBodyPropTypes = {
@@ -21,14 +22,20 @@ const moduleHeaderPropTypes = {
 
 const defaultProps = {
   size: 'fluid',
+  padding: false,
 };
 
 const moduleBodydefaultProps = {
   centered: false,
 };
 
-const Module = ({ children, className, size, ...rest }) => {
-  const wrapperClasses = classNames(`bx--module bx--module--${size}`, className);
+const Module = ({ children, className, size, padding, ...rest }) => {
+  const wrapperClasses = classNames(className, {
+    'bx--module': true,
+    'bx--module--fluid': size === 'fluid',
+    'bx--module--single': size === 'single',
+    'bx--module--padding': padding,
+  });
 
   return (
     <div className={wrapperClasses} {...rest}>

--- a/src/components/Module/_module.scss
+++ b/src/components/Module/_module.scss
@@ -10,7 +10,7 @@
     background-color: $ui-01;
     display: flex;
     flex-direction: column;
-    padding: 0 rem(32px);
+    padding: 0;
     flex: 1 0 auto;
     margin: 0;
 
@@ -62,6 +62,10 @@
 
     &.#{$prefix}--module--fluid {
       width: 100%;
+    }
+
+    &.#{$prefix}--module--padding {
+      padding: 0 rem(32px);
     }
   }
 }


### PR DESCRIPTION
Gives consumers the option to have full with or padded module components

#### Changelog

**New**

- Padding prop for module component

**Changed**

- Module no longer has padding set by default. This is the expected behaviour from previous versions

**Removed**

- Padding by default