### PR TITLE
Module inner padding

### DIFF
--- a/src/components/Module/_module.scss
+++ b/src/components/Module/_module.scss
@@ -21,8 +21,7 @@
     .#{$prefix}--module__header {
       display: flex;
       align-items: center;
-      padding-bottom: rem(16px);
-      padding-top: rem(24px);
+      padding: rem(24px) 0 rem(16px) 0;
       border-bottom: 1px solid $ui-04;
     }
 
@@ -36,8 +35,7 @@
       display: flex;
       flex-direction: column;
       flex: 3;
-      padding-top: rem(24px);
-      padding-bottom: rem(32px);
+      padding: rem(24px) 0 rem(32px) 0;
 
       p {
         @include type-scale-item(c, false);

--- a/src/components/Module/_module.scss
+++ b/src/components/Module/_module.scss
@@ -3,7 +3,7 @@
 @import '~carbon-components/src/globals/scss/import-once';
 @import '../../globals/type/ics-typography';
 
-@include exports('module--ics') {
+@include exports('module') {
   .#{$prefix}--module {
     @include reset;
     @include font-family;


### PR DESCRIPTION
Explicitly sets left and right padding values to module. Also, removes `--ics` from named export, as this SASS is intended to replace, rather than override Carbon's module.

#### Changelog

**Removed**

- ICS suffix from SASS export
