### PR TITLE
refactor(Overrides)

### DIFF
--- a/.storybook/test.scss
+++ b/.storybook/test.scss
@@ -1,0 +1,4 @@
+// Test with Carbon using this file
+@import '../src/globals/theme/_ics-theme.scss';
+@import '~carbon-components/scss/globals/scss/styles.scss';
+@import '../src/index.scss';

--- a/src/components/InteriorLeftNav/InteriorLeftNav-test.js
+++ b/src/components/InteriorLeftNav/InteriorLeftNav-test.js
@@ -13,7 +13,7 @@ describe('InteriorLeftNav', () => {
     });
 
     it('has the expected classes', () => {
-      expect(wrapper.children().hasClass('bx--interior-left-nav')).toEqual(true);
+      expect(wrapper.children().hasClass('bx--interior-left-nav-ics')).toEqual(true);
     });
 
     it('should add extra classes that are passed via className', () => {

--- a/src/components/InteriorLeftNav/InteriorLeftNav.js
+++ b/src/components/InteriorLeftNav/InteriorLeftNav.js
@@ -103,7 +103,7 @@ export default class InteriorLeftNav extends Component {
       return child;
     });
 
-    const classNames = classnames('bx--interior-left-nav', className);
+    const classNames = classnames('bx--interior-left-nav-ics', className);
 
     return (
       <nav

--- a/src/components/InteriorLeftNav/_interior-left-nav.scss
+++ b/src/components/InteriorLeftNav/_interior-left-nav.scss
@@ -5,7 +5,7 @@
 @import '../../globals/bidi/bidi';
 
 @include exports('interior-left-nav--ics') {
-  .#{$prefix}--interior-left-nav {
+  .#{$prefix}--interior-left-nav-ics {
     @include font-family;
     @include type-scale-item(b, false);
     position: relative;

--- a/src/components/Module/Module.js
+++ b/src/components/Module/Module.js
@@ -31,7 +31,7 @@ const moduleBodydefaultProps = {
 
 const Module = ({ children, className, size, padding, ...rest }) => {
   const wrapperClasses = classNames(className, {
-    'bx--module': true,
+    'bx--module-ics': true,
     'bx--module--fluid': size === 'fluid',
     'bx--module--single': size === 'single',
     'bx--module--padding': padding,

--- a/src/components/Module/_module.scss
+++ b/src/components/Module/_module.scss
@@ -5,10 +5,9 @@
 @import '../../globals/layer/ics-layer';
 
 @include exports('module--ics') {
-  .#{$prefix}--module {
+  .#{$prefix}--module-ics {
     @include reset;
     @include font-family;
-    @include layer(flat);
     background-color: $ui-01;
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
Gives original components with the same classnames as carbon-comonents, their own ICS specific classnames.

We have two components with the same classnames as soon-to-be-deprecated carbon components:
- InteriorLeftNav
- Module

We made the decision to create our own ICS stylesheets for these, rather than overriding.

However, if using this addons repo along with carbon's styles, this produces visual defects as the classnames are the same.

May break tests that refer to older classnames.

#### Changelog

**New**
- test.scss file to test our components locally with carbon stylesheets.

**Changed**

- Changes classnames on deprecated components
- Updates tests to reflect this

@stpCollabr8nLstn What do you think? Had originally put `--ics` on the end of these classnames, however these technically aren't BEM modifiers so I don't wanna break that convention or confuse people! Also good to note is this issue (along with deprecation warnings) should go away once these deprecated components are removed as part of carbon v9!