### PR TITLE
Modalwrapper on request close

### DIFF
--- a/src/components/ModalWrapper/ModalWrapper-story.js
+++ b/src/components/ModalWrapper/ModalWrapper-story.js
@@ -7,17 +7,6 @@ import { SelectItem, RadioButtonGroup, RadioButton } from 'carbon-components-rea
 import { withReadme } from 'storybook-readme';
 import readme from './README.md';
 
-const modalProps = {
-  onBlur: action('onBlur'),
-  onClick: action('onClick'),
-  onFocus: action('onFocus'),
-  onMouseDown: action('onMouseDown'),
-  onMouseEnter: action('onMouseEnter'),
-  onMouseLeave: action('onMouseLeave'),
-  onMouseUp: action('onMouseUp'),
-  className: 'some-class',
-};
-
 storiesOf('Components|ModalWrapper', module)
   .addDecorator(withReadme(readme))
   .add(
@@ -28,7 +17,6 @@ storiesOf('Components|ModalWrapper', module)
     `,
     )(() => (
       <ModalWrapper
-        modalProps={modalProps}
         id="transactional-dialog"
         buttonTriggerText="Transactional Dialog"
         modalHeading="Transactional Dialog"

--- a/src/components/ModalWrapper/ModalWrapper-story.js
+++ b/src/components/ModalWrapper/ModalWrapper-story.js
@@ -31,10 +31,10 @@ storiesOf('Components|ModalWrapper', module)
         modalProps={modalProps}
         id="transactional-dialog"
         buttonTriggerText="Transactional Dialog"
-        modalText="This is a transactional dialog"
         modalHeading="Transactional Dialog"
         primaryButtonText="Save"
         secondaryButtonText="Cancel"
+        onRequestClose={action('onRequestClose')}
         handleSubmit={action('onSubmit')}
       >
         <p className="bx--modal-content__text">
@@ -80,6 +80,7 @@ storiesOf('Components|ModalWrapper', module)
         modalText="This is a passive dialog"
         modalHeading="Passive Dialog"
         passiveModal
+        onRequestClose={action('onRequestClose')}
       >
         <p className="bx--modal-content__text">
           Passive modal notifications should only appear if there is an action the user needs to

--- a/src/components/ModalWrapper/ModalWrapper.js
+++ b/src/components/ModalWrapper/ModalWrapper.js
@@ -15,20 +15,25 @@ export default class ModalWrapper extends React.Component {
     status: PropTypes.string,
     handleOpen: PropTypes.func,
     children: PropTypes.node,
-    id: PropTypes.string,
     buttonTriggerText: PropTypes.string,
-    modalHeading: PropTypes.string,
-    modalText: PropTypes.string,
-    passiveModal: PropTypes.bool,
     withHeader: PropTypes.bool,
     modalBeforeContent: PropTypes.bool,
-    primaryButtonText: PropTypes.string,
-    secondaryButtonText: PropTypes.string,
     handleSubmit: PropTypes.func,
     disabled: PropTypes.bool,
     triggerButtonkind: PropTypes.oneOf(['primary', 'secondary', 'danger', 'ghost']),
     shouldCloseAfterSubmit: PropTypes.bool,
+    // Modal Props
+    id: PropTypes.string,
+    modalHeading: PropTypes.string,
+    passiveModal: PropTypes.bool,
+    primaryButtonText: PropTypes.string,
+    secondaryButtonText: PropTypes.string,
+    onRequestClose: PropTypes.func,
+    onRequestSubmit: PropTypes.func,
     onKeyDown: PropTypes.func,
+    iconDescription: PropTypes.string,
+    primaryButtonDisabled: PropTypes.bool,
+    onSecondarySubmit: PropTypes.func,
   };
 
   static defaultProps = {
@@ -36,6 +41,7 @@ export default class ModalWrapper extends React.Component {
     secondaryButtonText: 'Cancel',
     triggerButtonkind: 'primary',
     disabled: false,
+    onRequestClose: () => {},
     onKeyDown: () => {},
   };
 
@@ -46,6 +52,7 @@ export default class ModalWrapper extends React.Component {
   };
 
   handleClose = () => {
+    this.props.onRequestClose();
     this.setState({
       open: false,
     });
@@ -80,6 +87,9 @@ export default class ModalWrapper extends React.Component {
       handleSubmit, // eslint-disable-line no-unused-vars
       disabled,
       onKeyDown, // eslint-disable-line no-unused-vars
+      iconDescription,
+      primaryButtonDisabled,
+      onSecondarySubmit,
     } = this.props;
 
     const props = {
@@ -91,6 +101,10 @@ export default class ModalWrapper extends React.Component {
       open: this.state.open,
       onRequestClose: this.handleClose,
       onRequestSubmit: this.handleOnRequestSubmit,
+      onKeyDown,
+      iconDescription,
+      primaryButtonDisabled,
+      onSecondarySubmit,
     };
 
     return (

--- a/src/components/ModalWrapper/__snapshots__/ModalWrapper-test.js.snap
+++ b/src/components/ModalWrapper/__snapshots__/ModalWrapper-test.js.snap
@@ -8,6 +8,7 @@ exports[`ModalWrapper should render 1`] = `
   id="modal"
   modalHeading="Transactional Modal"
   onKeyDown={[Function]}
+  onRequestClose={[Function]}
   primaryButtonText="Save"
   secondaryButtonText="Cancel"
   shouldCloseAfterSubmit={true}


### PR DESCRIPTION
Closes carbon-design-system/carbon-addons-ics#

 Consumers using ModalWrapper are unable to pass Modal props via ModalWrapper

#### Changelog

**New**

- Add all Modal props to ModalWrapper
- Update snapshot

**Removed**

- `modalProps` was not being used/passed anywhere 
- `modalText` was not being used anywhere