### PR TITLE
335 input error styling

### DIFF
--- a/src/components/Form/_form.scss
+++ b/src/components/Form/_form.scss
@@ -34,10 +34,12 @@
     ~ .#{$prefix}--form-requirement {
       color: $support-01;
     }
+
     ~ .#{$prefix}--form-requirement:before {
       content: '';
       display: none;
     }
+
     &:focus ~ .#{$prefix}--mi__underline {
       &:before,
       &:after {

--- a/src/components/Form/_form.scss
+++ b/src/components/Form/_form.scss
@@ -28,6 +28,22 @@
   select:invalid {
     box-shadow: 0 1px 0px 0px $support-01;
     border-color: $support-01;
+
+    &:focus ~ .#{$prefix}--label,
+    ~ .#{$prefix}--label-motion,
+    ~ .#{$prefix}--form-requirement {
+      color: $support-01;
+    }
+    ~ .#{$prefix}--form-requirement:before {
+      content: '';
+      display: none;
+    }
+    &:focus ~ .#{$prefix}--mi__underline {
+      &:before,
+      &:after {
+        background: $support-01;
+      }
+    }
   }
 
   .#{$prefix}--form-requirement {


### PR DESCRIPTION
Closes carbon-design-system/carbon-addons-ics#335

"make label red, asetrisk * replaced with word "error". message in red"

#### Changelog

**Changed**
For inputs with errors:
- red label 
- red underline
- red error text

**Removed**
- Added overrides to remove * from beginning of error message.

![image](https://user-images.githubusercontent.com/3826294/37848722-8e32a7c4-2eab-11e8-9d2b-6cf1d8b1adc4.png)

