### PR TITLE
Interior left nav updates

### DIFF
--- a/src/components/InteriorLeftNav/InteriorLeftNav-story.js
+++ b/src/components/InteriorLeftNav/InteriorLeftNav-story.js
@@ -26,7 +26,7 @@ storiesOf('Components|InteriorLeftNav', module)
             <a href="#example-3">Icons</a>
           </InteriorLeftNavItem>
           <InteriorLeftNavItem>
-            <a href="#example-4">Gradients</a>
+            <a href="/iframe.html">Gradients</a>
           </InteriorLeftNavItem>
           <InteriorLeftNavItem>
             <a href="#example-5">Icons</a>

--- a/src/components/InteriorLeftNav/InteriorLeftNav.js
+++ b/src/components/InteriorLeftNav/InteriorLeftNav.js
@@ -49,6 +49,7 @@ export default class InteriorLeftNav extends Component {
 
   buildNewListChild = (child, index) => {
     let open = false;
+
     React.Children.map(child.props.children, c => {
       const { href, to } = c.props.children.props;
       const childHref = href === undefined ? to : href;

--- a/src/components/InteriorLeftNav/InteriorLeftNav.js
+++ b/src/components/InteriorLeftNav/InteriorLeftNav.js
@@ -48,6 +48,13 @@ export default class InteriorLeftNav extends Component {
   };
 
   buildNewListChild = (child, index) => {
+    let open = false;
+    React.Children.map(child.props.children, c => {
+      const { href, to } = c.props.children.props;
+      const childHref = href === undefined ? to : href;
+      if (childHref === this.state.activeHref) open = true;
+    });
+
     const key = `list-${index}`;
     return (
       <InteriorLeftNavList
@@ -58,6 +65,7 @@ export default class InteriorLeftNav extends Component {
         onListClick={this.handleListClick}
         onItemClick={this.handleItemClick}
         activeHref={this.state.activeHref}
+        open={open}
       />
     );
   };

--- a/src/components/InteriorLeftNav/InteriorLeftNav.js
+++ b/src/components/InteriorLeftNav/InteriorLeftNav.js
@@ -17,11 +17,6 @@ export default class InteriorLeftNav extends Component {
     children: PropTypes.node,
     className: PropTypes.string,
     activeHref: PropTypes.string,
-    onToggle: PropTypes.func,
-  };
-
-  static defaultProps = {
-    onToggle: () => {},
   };
 
   componentWillReceiveProps = nextProps => {
@@ -50,12 +45,6 @@ export default class InteriorLeftNav extends Component {
         }
       }
     });
-  };
-
-  toggle = evt => {
-    evt.stopPropagation();
-    this.props.onToggle(!this.state.open);
-    this.setState({ open: !this.state.open });
   };
 
   buildNewListChild = (child, index) => {
@@ -90,7 +79,6 @@ export default class InteriorLeftNav extends Component {
       className,
       children,
       activeHref, // eslint-disable-line no-unused-vars
-      onToggle, // eslint-disable-line no-unused-vars
       ...rest
     } = this.props;
 
@@ -111,8 +99,6 @@ export default class InteriorLeftNav extends Component {
         tabIndex={-1}
         aria-label="Interior Left Navigation"
         className={classNames}
-        onClick={!this.state.open ? this.toggle : () => {}}
-        onKeyPress={!this.state.open ? this.toggle : () => {}}
         {...rest}
       >
         <ul key="main_list" className="left-nav-list" role="menubar">

--- a/src/components/InteriorLeftNavItem/InteriorLeftNavItem.js
+++ b/src/components/InteriorLeftNavItem/InteriorLeftNavItem.js
@@ -13,12 +13,10 @@ const newChild = (children, tabIndex) => {
 
 const InteriorLeftNavItem = ({ className, tabIndex, children, onClick, activeHref, ...rest }) => {
   const childHref = children.props.href === undefined ? children.props.to : children.props.href;
-  const activePath = activeHref || (window.location && window.location.hash);
+  const activePath = window.location && window.location.hash ? window.location.hash : activeHref;
   const classNames = classnames('left-nav-list__item', className, {
     'left-nav-list__item--active': activePath === childHref,
   });
-
-  //isActive(activePath === childHref);
 
   return (
     <li

--- a/src/components/InteriorLeftNavItem/InteriorLeftNavItem.js
+++ b/src/components/InteriorLeftNavItem/InteriorLeftNavItem.js
@@ -13,10 +13,12 @@ const newChild = (children, tabIndex) => {
 
 const InteriorLeftNavItem = ({ className, tabIndex, children, onClick, activeHref, ...rest }) => {
   const childHref = children.props.href === undefined ? children.props.to : children.props.href;
-  const activePath = window.location && window.location.hash ? window.location.hash : activeHref;
+  const activePath = activeHref || (window.location && window.location.hash);
   const classNames = classnames('left-nav-list__item', className, {
     'left-nav-list__item--active': activePath === childHref,
   });
+
+  //isActive(activePath === childHref);
 
   return (
     <li

--- a/src/components/InteriorLeftNavList/InteriorLeftNavList.js
+++ b/src/components/InteriorLeftNavList/InteriorLeftNavList.js
@@ -1,3 +1,4 @@
+//import window from 'window-or-global';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import classnames from 'classnames';
@@ -7,9 +8,14 @@ import Icon from '../Icon';
 export default class InteriorLeftNavList extends Component {
   constructor(props) {
     super(props);
+
+    //const activePath = activeHref || (window.location && window.location.hash);
+
     this.state = {
       open: this.props.open,
     };
+
+    //this.props.children.filter(child => (child.props.href === this.props.activeHref)) ? true :
   }
 
   static propTypes = {
@@ -52,6 +58,11 @@ export default class InteriorLeftNavList extends Component {
     const { onItemClick, activeHref } = this.props;
 
     const key = `listitem-${index}`;
+
+    // eslint-disable-next-line no-console
+    //console.log(child.props.children.props.href); //
+    //const childHref = child.props.children.props.href === undefined ? child.props.children.props.to : child.props.children.props.href;
+
     return (
       <InteriorLeftNavItem
         {...child.props}

--- a/src/components/InteriorLeftNavList/InteriorLeftNavList.js
+++ b/src/components/InteriorLeftNavList/InteriorLeftNavList.js
@@ -8,14 +8,9 @@ import Icon from '../Icon';
 export default class InteriorLeftNavList extends Component {
   constructor(props) {
     super(props);
-
-    //const activePath = activeHref || (window.location && window.location.hash);
-
     this.state = {
       open: this.props.open,
     };
-
-    //this.props.children.filter(child => (child.props.href === this.props.activeHref)) ? true :
   }
 
   static propTypes = {
@@ -58,14 +53,6 @@ export default class InteriorLeftNavList extends Component {
     const { onItemClick, activeHref } = this.props;
 
     const key = `listitem-${index}`;
-
-    // eslint-disable-next-line no-console
-    //console.log(child);
-
-    // eslint-disable-next-line no-console
-    //console.log(child.props.children.props.href); //
-    //const childHref = child.props.children.props.href === undefined ? child.props.children.props.to : child.props.children.props.href;
-
     return (
       <InteriorLeftNavItem
         {...child.props}

--- a/src/components/InteriorLeftNavList/InteriorLeftNavList.js
+++ b/src/components/InteriorLeftNavList/InteriorLeftNavList.js
@@ -60,6 +60,9 @@ export default class InteriorLeftNavList extends Component {
     const key = `listitem-${index}`;
 
     // eslint-disable-next-line no-console
+    //console.log(child);
+
+    // eslint-disable-next-line no-console
     //console.log(child.props.children.props.href); //
     //const childHref = child.props.children.props.href === undefined ? child.props.children.props.to : child.props.children.props.href;
 


### PR DESCRIPTION
Removes responsive toggle behaviour on InteriorLeftNav, as this isn't an ICS pattern. Also gets InteriorLeftNav to check if lists contain an activeHref, and to toggle the list open if this is the case.

#### Changelog

**New**

- ActiveHref in list automatically toggles the list open

**Removed**

- Removes toggle / collapse behaviour inherited from carbon
