### PR TITLE
1176 select firefox

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -539,6 +539,16 @@
       "integrity": "sha512-CTUtLb6WqCCgp6P59QintjHWqzf4VL1uPA27bipLAPxFqrtK1gEYllePzTICGqQ8rYsCbpnsNypXjjDzGAAjEQ==",
       "dev": true
     },
+    "JSONStream": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.2.tgz",
+      "integrity": "sha1-wQI3G27Dp887hHygDCC7D85Mbeo=",
+      "dev": true,
+      "requires": {
+        "jsonparse": "1.3.1",
+        "through": "2.3.8"
+      }
+    },
     "abab": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/abab/-/abab-1.0.4.tgz",
@@ -4054,8 +4064,8 @@
       "integrity": "sha512-jaAP61py+ISMF3/n3yIiIuY5h6mJlucOqawu5mLB1HaQADLvg/y5UB3pT7HSucZJan34lp7+7ylQPfbKEGmxrA==",
       "dev": true,
       "requires": {
-        "is-text-path": "1.0.1",
         "JSONStream": "1.3.2",
+        "is-text-path": "1.0.1",
         "lodash": "4.17.5",
         "meow": "4.0.0",
         "split2": "2.2.0",
@@ -7438,14 +7448,6 @@
             }
           }
         },
-        "string_decoder": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "safe-buffer": "5.0.1"
-          }
-        },
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
@@ -7454,6 +7456,14 @@
             "code-point-at": "1.1.0",
             "is-fullwidth-code-point": "1.0.0",
             "strip-ansi": "3.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
           }
         },
         "stringstream": {
@@ -10287,16 +10297,6 @@
       "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
       "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
       "dev": true
-    },
-    "JSONStream": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.2.tgz",
-      "integrity": "sha1-wQI3G27Dp887hHygDCC7D85Mbeo=",
-      "dev": true,
-      "requires": {
-        "jsonparse": "1.3.1",
-        "through": "2.3.8"
-      }
     },
     "jsprim": {
       "version": "1.4.1",
@@ -17300,15 +17300,6 @@
       "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
       "dev": true
     },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
-    },
     "string-length": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/string-length/-/string-length-2.0.0.tgz",
@@ -17373,6 +17364,15 @@
         "define-properties": "1.1.2",
         "es-abstract": "1.10.0",
         "function-bind": "1.1.1"
+      }
+    },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.1"
       }
     },
     "stringify-object": {

--- a/src/components/Select/_select.scss
+++ b/src/components/Select/_select.scss
@@ -34,6 +34,11 @@
       outline: none;
       @include mi-underline-focus;
     }
+
+    &:-moz-focusring {
+      color: transparent;
+      text-shadow: 0 0 0 $text-01;
+    }
   }
 
   .#{$prefix}--select__arrow {

--- a/src/components/Select/_select.scss
+++ b/src/components/Select/_select.scss
@@ -34,6 +34,10 @@
       outline: none;
       @include mi-underline-focus;
     }
+    &:-moz-focusring {
+      color: transparent;
+      text-shadow: 0 0 0 $text-01;
+    }
   }
 
   .#{$prefix}--select__arrow {

--- a/src/components/Select/_select.scss
+++ b/src/components/Select/_select.scss
@@ -58,6 +58,10 @@
     }
   }
 
+  .#{$prefix}--select-option {
+    padding: 0.25rem;
+  }
+
   // Override some Firefox user-agent styles
   @-moz-document url-prefix() {
     .#{$prefix}--select-option {

--- a/src/components/Select/_select.scss
+++ b/src/components/Select/_select.scss
@@ -34,10 +34,6 @@
       outline: none;
       @include mi-underline-focus;
     }
-    &:-moz-focusring {
-      color: transparent;
-      text-shadow: 0 0 0 $text-01;
-    }
   }
 
   .#{$prefix}--select__arrow {


### PR DESCRIPTION
Removed focus outline on select in firefox. There is a known issue in FF where it ignores outline rules on focused selects. The workaround I used is based on the fact that the focus outline uses the text color. I set the text color to transparent, and added a text shadow without an offset or blur so it appears to be normal text.

A11y: high contrast mode removes text shadows and changes colors to what the user picks, so there is no a11y issue.

I also added padding to the options so they look less cramped in FF.

#### Changelog

**Changed**
![image](https://user-images.githubusercontent.com/3826294/38756604-1dd236b4-3f38-11e8-84dc-485f455049c3.png)



