### PR TITLE
fix: long text input labels should have their overflow ellipsed

### DIFF
--- a/src/components/TextInput/_text-input.scss
+++ b/src/components/TextInput/_text-input.scss
@@ -44,6 +44,10 @@
     ~ .#{$prefix}--label {
       @include type-scale-item(c, false);
       position: absolute;
+      width: 100%;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
       top: rem(-4px);
       @include bidi-left(0);
       -webkit-transition: 0.2s ease all;


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon-addons-ics/issues/43

Currently, text input labels wrap to a second line if they are too long, which looks funky and mildly interferes with their usability.  With this, the labels are truncated at 100% width (of the text input itself):

![image](https://user-images.githubusercontent.com/1596764/39274404-d4e9749a-48af-11e8-89db-9b6b95cac316.png)

![image](https://user-images.githubusercontent.com/1596764/39274414-db9b9e4e-48af-11e8-9ada-47490ec97f83.png)


#### Changelog

**Changed**

- [TextInput] give labels overflow: ellipses styling
