### PR TITLE
fix(FormGroup): Data invalid form requirement styling

### DIFF
--- a/src/components/Form/Form-story.js
+++ b/src/components/Form/Form-story.js
@@ -124,12 +124,7 @@ storiesOf('Components|Form', module)
     'default',
     withInfo(``)(() => (
       <Form {...additionalProps}>
-        <FormGroup
-          invalid={true}
-          message={true}
-          messageText="There is an error"
-          {...fieldsetCheckboxProps}
-        >
+        <FormGroup {...fieldsetCheckboxProps}>
           <Checkbox defaultChecked {...checkboxEvents} id="checkbox-0" />
           <Checkbox {...checkboxEvents} id="checkbox-1" />
           <Checkbox disabled {...checkboxEvents} id="checkbox-2" />
@@ -201,7 +196,7 @@ storiesOf('Components|Form', module)
           />
         </FormGroup>
         <FormGroup {...fieldsetTextareaProps}>
-          <TextArea invalid={true} invalidText="This is wrong" {...textareaProps} />
+          <TextArea {...textareaProps} />
         </FormGroup>
         <div>
           <Button type="submit" className="some-class" {...buttonEvents}>

--- a/src/components/Form/Form-story.js
+++ b/src/components/Form/Form-story.js
@@ -124,7 +124,12 @@ storiesOf('Components|Form', module)
     'default',
     withInfo(``)(() => (
       <Form {...additionalProps}>
-        <FormGroup {...fieldsetCheckboxProps}>
+        <FormGroup
+          invalid={true}
+          message={true}
+          messageText="There is an error"
+          {...fieldsetCheckboxProps}
+        >
           <Checkbox defaultChecked {...checkboxEvents} id="checkbox-0" />
           <Checkbox {...checkboxEvents} id="checkbox-1" />
           <Checkbox disabled {...checkboxEvents} id="checkbox-2" />
@@ -196,7 +201,7 @@ storiesOf('Components|Form', module)
           />
         </FormGroup>
         <FormGroup {...fieldsetTextareaProps}>
-          <TextArea {...textareaProps} />
+          <TextArea invalid={true} invalidText="This is wrong" {...textareaProps} />
         </FormGroup>
         <div>
           <Button type="submit" className="some-class" {...buttonEvents}>

--- a/src/components/Form/_form.scss
+++ b/src/components/Form/_form.scss
@@ -21,6 +21,12 @@
     margin-bottom: rem(4px);
   }
 
+  fieldset[data-invalid] {
+    .#{$prefix}--form__requirements {
+      color: $support-01;
+    }
+  }
+
   input[data-invalid],
   textarea[data-invalid],
   select[data-invalid],
@@ -48,7 +54,8 @@
     }
   }
 
-  .#{$prefix}--form-requirement {
+  .#{$prefix}--form-requirement,
+  .#{$prefix}--form__requirements {
     @include type-scale-item(a, false);
     margin: 0.75rem 0 0;
   }


### PR DESCRIPTION
The invalid `FormGroup` message was previously un-styled. This adds the equivalent styling from other input fields

#### Changelog

**New**

- Adds `FormGroup` invalid message styles
