### PR TITLE
refactor(list): Update the indent / left margin of lists

### DIFF
--- a/src/components/List/_list.scss
+++ b/src/components/List/_list.scss
@@ -8,7 +8,7 @@
   .#{$prefix}--list--unordered,
   .#{$prefix}--list--ordered {
     @include type-scale-item(c, false);
-    @include bidi-margin-left(1.5rem);
+    @include bidi-margin-left(0);
     direction: $direction;
   }
 
@@ -21,7 +21,7 @@
 
   .#{$prefix}--list--unordered,
   .#{$prefix}--list--ordered {
-    padding: 1rem 2rem;
+    padding: 1rem 2rem 1rem 1.25rem;
   }
 
   .#{$prefix}--list--nested {


### PR DESCRIPTION
Make the list bullets / numbers flush left with surrounding non-list text elements

Closes carbon-design-system/carbon-addons-ics#1318

![image](https://user-images.githubusercontent.com/3826294/40861935-e07bf262-65b8-11e8-830b-176fb31169a9.png)


#### Changelog

**Changed**

- list margin left and padding left
