### PR TITLE
Fixed the background colour wrongly set for modal

### DIFF
--- a/src/components/Modal/_modal.scss
+++ b/src/components/Modal/_modal.scss
@@ -9,8 +9,6 @@
 
 @include exports('modal--ics') {
   .#{$prefix}--modal {
-    background-color: $inverse-01;
-
     &.is-visible {
       background: rgba(0, 0, 0, 0.75);
     }


### PR DESCRIPTION
Closes carbon-design-system/carbon-addons-ics#

When the modal is closed, a slight flash in the background screen happens and the reason is the background colour set as white. See gif below: 

![flash-screen-closing-modal](https://user-images.githubusercontent.com/5923573/51544526-10d72000-1e58-11e9-8b64-5a60fe96d197.jpeg)


