### PR TITLE
fix: overflow menu support for ie

### DIFF
--- a/src/globals/internal/FloatingMenu.js
+++ b/src/globals/internal/FloatingMenu.js
@@ -249,7 +249,7 @@ class FloatingMenu extends React.Component {
             refPosition,
             direction: menuDirection,
             offset,
-            scrollY: window.scrollY,
+            scrollY: window.pageYOffset,
           }),
         });
       }


### PR DESCRIPTION
Closes carbon-design-system/carbon-addons-ics#

window.scrollY doesn't exist in windows

#### Changelog


**Changed**

- window.scrollY to window.pageYOffset

